### PR TITLE
breaking: drop node v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.x]
+        node: [20]
 
     runs-on: ${{ matrix.os }}
 
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.x]
+        node: [20]
 
     runs-on: ${{ matrix.os }}
 
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.x]
+        node: [20]
 
     runs-on: ${{ matrix.os }}
 
@@ -182,7 +182,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
     steps:
       - name: Checkout codes
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Enable corepack
         run: corepack enable

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "type": "module",
   "sideEffects": false,
@@ -125,5 +125,6 @@
     "unbuild": "^2.0.0",
     "vitest": "^1.3.0",
     "vitest-environment-miniflare": "^2.14.1"
-  }
+  },
+  "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903"
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/utils/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement to 20.
  * Configured pnpm as the official package manager with version specifications.
  * Updated CI/CD workflows to use Node.js 20 across all build, test, and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->