### PR TITLE
fix: add deprecation tag for h3 and hono JSDoc

### DIFF
--- a/docs/h3/functions/getCookieLocale.md
+++ b/docs/h3/functions/getCookieLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getCookieLocale
 
-# Function: getCookieLocale()
+# ~~Function: getCookieLocale()~~
 
 ```ts
 function getCookieLocale(event, options): Locale;
@@ -43,3 +43,7 @@ app.use(eventHandler(event) => {
 ## Throws
 
 Throws a `RangeError` if `lang` option or cookie name value are not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getCookieLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/getHeaderLanguage.md
+++ b/docs/h3/functions/getHeaderLanguage.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getHeaderLanguage
 
-# Function: getHeaderLanguage()
+# ~~Function: getHeaderLanguage()~~
 
 ```ts
 function getHeaderLanguage(event, options): string;
@@ -44,3 +44,7 @@ app.use(eventHandler(event) => {
   return `accepted language: ${langTag}`
 })
 ```
+
+## Deprecated
+
+since v2. Use `getHeaderLanguage` of `@intlify/utils` instead.

--- a/docs/h3/functions/getHeaderLanguages.md
+++ b/docs/h3/functions/getHeaderLanguages.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getHeaderLanguages
 
-# Function: getHeaderLanguages()
+# ~~Function: getHeaderLanguages()~~
 
 ```ts
 function getHeaderLanguages(event, options): string[];
@@ -44,3 +44,7 @@ app.use(eventHandler(event) => {
   return `accepted languages: ${acceptLanguages.join(', ')}`
 })
 ```
+
+## Deprecated
+
+since v2. Use `getHeaderLanguages` of `@intlify/utils` instead.

--- a/docs/h3/functions/getHeaderLocale.md
+++ b/docs/h3/functions/getHeaderLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getHeaderLocale
 
-# Function: getHeaderLocale()
+# ~~Function: getHeaderLocale()~~
 
 ```ts
 function getHeaderLocale(event, options): Locale;
@@ -47,3 +47,7 @@ app.use(eventHandler(event) => {
 ## Throws
 
 Throws the `RangeError` if `lang` option or header are not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getHeaderLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/getHeaderLocales.md
+++ b/docs/h3/functions/getHeaderLocales.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getHeaderLocales
 
-# Function: getHeaderLocales()
+# ~~Function: getHeaderLocales()~~
 
 ```ts
 function getHeaderLocales(event, options): Locale[];
@@ -47,3 +47,7 @@ app.use(eventHandler(event) => {
 ## Throws
 
 Throws the `RangeError` if header are not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getHeaderLocales` of `@intlify/utils` instead.

--- a/docs/h3/functions/getPathLocale.md
+++ b/docs/h3/functions/getPathLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getPathLocale
 
-# Function: getPathLocale()
+# ~~Function: getPathLocale()~~
 
 ```ts
 function getPathLocale(event, options): Locale;
@@ -28,3 +28,7 @@ The locale that resolved from path
 ## Throws
 
 Throws the `RangeError` if the language in the path, that is not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getPathLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/getQueryLocale.md
+++ b/docs/h3/functions/getQueryLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / getQueryLocale
 
-# Function: getQueryLocale()
+# ~~Function: getQueryLocale()~~
 
 ```ts
 function getQueryLocale(event, options): Locale;
@@ -28,3 +28,7 @@ The locale that resolved from query
 ## Throws
 
 Throws the `RangeError` if the language in the query, that is not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getQueryLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/setCookieLocale.md
+++ b/docs/h3/functions/setCookieLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / setCookieLocale
 
-# Function: setCookieLocale()
+# ~~Function: setCookieLocale()~~
 
 ```ts
 function setCookieLocale(
@@ -44,3 +44,7 @@ app.use(eventHandler(event) => {
 ## Throws
 
 Throws the `SyntaxError` if `locale` is invalid.
+
+## Deprecated
+
+since v2. Use `setCookieLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/tryCookieLocale.md
+++ b/docs/h3/functions/tryCookieLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / tryCookieLocale
 
-# Function: tryCookieLocale()
+# ~~Function: tryCookieLocale()~~
 
 ```ts
 function tryCookieLocale(event, options): Locale | null;
@@ -28,3 +28,7 @@ The locale that resolved from cookie. if `lang` option or cookie name value are 
 ## Description
 
 Unlike [`getCookieLocale`](getCookieLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryCookieLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/tryHeaderLocale.md
+++ b/docs/h3/functions/tryHeaderLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / tryHeaderLocale
 
-# Function: tryHeaderLocale()
+# ~~Function: tryHeaderLocale()~~
 
 ```ts
 function tryHeaderLocale(event, options): Locale | null;
@@ -28,3 +28,7 @@ The first locale that resolved from header string. if you use `accept-language` 
 ## Description
 
 wrap language tag with Intl.Locale \| locale, languages tags will be parsed from `accept-language` header as default. Unlike [getHeaderLocale](getHeaderLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryHeaderLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/tryHeaderLocales.md
+++ b/docs/h3/functions/tryHeaderLocales.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / tryHeaderLocales
 
-# Function: tryHeaderLocales()
+# ~~Function: tryHeaderLocales()~~
 
 ```ts
 function tryHeaderLocales(event, options): Locale[] | null;
@@ -28,3 +28,7 @@ The locales that wrapped from header, if you use `accept-language` header and `*
 ## Description
 
 wrap language tags with Intl.Locale \| locale, languages tags will be parsed from `accept-language` header as default. Unlike [getHeaderLocales](getHeaderLocales.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryHeaderLocales` of `@intlify/utils` instead.

--- a/docs/h3/functions/tryPathLocale.md
+++ b/docs/h3/functions/tryPathLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / tryPathLocale
 
-# Function: tryPathLocale()
+# ~~Function: tryPathLocale()~~
 
 ```ts
 function tryPathLocale(event, options): Locale | null;
@@ -28,3 +28,7 @@ The locale that resolved from path. if the language in the path, that is not a w
 ## Description
 
 Unlike [`getPathLocale`](getPathLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryPathLocale` of `@intlify/utils` instead.

--- a/docs/h3/functions/tryQueryLocale.md
+++ b/docs/h3/functions/tryQueryLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [h3](../index.md) / tryQueryLocale
 
-# Function: tryQueryLocale()
+# ~~Function: tryQueryLocale()~~
 
 ```ts
 function tryQueryLocale(event, options): Locale | null;
@@ -28,3 +28,7 @@ The locale that resolved from query. if the language in the query, that is not a
 ## Description
 
 Unlike [`getQueryLocale`](getQueryLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryQueryLocale` of `@intlify/utils` instead.

--- a/docs/h3/index.md
+++ b/docs/h3/index.md
@@ -18,16 +18,16 @@ import { getHeaderLocale } from '@intlify/utils/h3'
 
 | Function | Description |
 | ------ | ------ |
-| [getCookieLocale](functions/getCookieLocale.md) | get locale from cookie |
-| [getHeaderLanguage](functions/getHeaderLanguage.md) | get language from header |
-| [getHeaderLanguages](functions/getHeaderLanguages.md) | get languages from header |
-| [getHeaderLocale](functions/getHeaderLocale.md) | get locale from header |
-| [getHeaderLocales](functions/getHeaderLocales.md) | get locales from header |
-| [getPathLocale](functions/getPathLocale.md) | get the locale from the path |
-| [getQueryLocale](functions/getQueryLocale.md) | get the locale from the query |
-| [setCookieLocale](functions/setCookieLocale.md) | set locale to the response `Set-Cookie` header. |
-| [tryCookieLocale](functions/tryCookieLocale.md) | try to get locale from cookie |
-| [tryHeaderLocale](functions/tryHeaderLocale.md) | try to get locale from header |
-| [tryHeaderLocales](functions/tryHeaderLocales.md) | try to get locales from header |
-| [tryPathLocale](functions/tryPathLocale.md) | try to get the locale from the path |
-| [tryQueryLocale](functions/tryQueryLocale.md) | try to get the locale from the query |
+| [~~getCookieLocale~~](functions/getCookieLocale.md) | get locale from cookie |
+| [~~getHeaderLanguage~~](functions/getHeaderLanguage.md) | get language from header |
+| [~~getHeaderLanguages~~](functions/getHeaderLanguages.md) | get languages from header |
+| [~~getHeaderLocale~~](functions/getHeaderLocale.md) | get locale from header |
+| [~~getHeaderLocales~~](functions/getHeaderLocales.md) | get locales from header |
+| [~~getPathLocale~~](functions/getPathLocale.md) | get the locale from the path |
+| [~~getQueryLocale~~](functions/getQueryLocale.md) | get the locale from the query |
+| [~~setCookieLocale~~](functions/setCookieLocale.md) | set locale to the response `Set-Cookie` header. |
+| [~~tryCookieLocale~~](functions/tryCookieLocale.md) | try to get locale from cookie |
+| [~~tryHeaderLocale~~](functions/tryHeaderLocale.md) | try to get locale from header |
+| [~~tryHeaderLocales~~](functions/tryHeaderLocales.md) | try to get locales from header |
+| [~~tryPathLocale~~](functions/tryPathLocale.md) | try to get the locale from the path |
+| [~~tryQueryLocale~~](functions/tryQueryLocale.md) | try to get the locale from the query |

--- a/docs/hono/functions/getCookieLocale.md
+++ b/docs/hono/functions/getCookieLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getCookieLocale
 
-# Function: getCookieLocale()
+# ~~Function: getCookieLocale()~~
 
 ```ts
 function getCookieLocale(context, options): Locale;
@@ -44,3 +44,7 @@ app.use('/', c => {
 ## Throws
 
 Throws a `RangeError` if `lang` option or cookie name value are not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getCookieLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/getHeaderLanguage.md
+++ b/docs/hono/functions/getHeaderLanguage.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getHeaderLanguage
 
-# Function: getHeaderLanguage()
+# ~~Function: getHeaderLanguage()~~
 
 ```ts
 function getHeaderLanguage(context, options): string;
@@ -44,3 +44,7 @@ app.use('/', c => {
   return c.text(`accepted language: ${langTag}`)
 })
 ```
+
+## Deprecated
+
+since v2. Use `getHeaderLanguage` of `@intlify/utils` instead.

--- a/docs/hono/functions/getHeaderLanguages.md
+++ b/docs/hono/functions/getHeaderLanguages.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getHeaderLanguages
 
-# Function: getHeaderLanguages()
+# ~~Function: getHeaderLanguages()~~
 
 ```ts
 function getHeaderLanguages(context, options): string[];
@@ -44,3 +44,7 @@ app.use('/', c => {
   return c.text(`accepted languages: ${acceptLanguages.join(', ')}`)
 })
 ```
+
+## Deprecated
+
+since v2. Use `getHeaderLanguages` of `@intlify/utils` instead.

--- a/docs/hono/functions/getHeaderLocale.md
+++ b/docs/hono/functions/getHeaderLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getHeaderLocale
 
-# Function: getHeaderLocale()
+# ~~Function: getHeaderLocale()~~
 
 ```ts
 function getHeaderLocale(context, options): Locale;
@@ -48,3 +48,7 @@ app.use('/', c => {
 ## Throws
 
 Throws the `RangeError` if `lang` option or header are not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getHeaderLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/getHeaderLocales.md
+++ b/docs/hono/functions/getHeaderLocales.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getHeaderLocales
 
-# Function: getHeaderLocales()
+# ~~Function: getHeaderLocales()~~
 
 ```ts
 function getHeaderLocales(context, options): Locale[];
@@ -48,3 +48,7 @@ app.use('/', c => {
 ## Throws
 
 Throws the `RangeError` if header are not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getHeaderLocales` of `@intlify/utils` instead.

--- a/docs/hono/functions/getPathLocale.md
+++ b/docs/hono/functions/getPathLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getPathLocale
 
-# Function: getPathLocale()
+# ~~Function: getPathLocale()~~
 
 ```ts
 function getPathLocale(context, options): Locale;
@@ -28,3 +28,7 @@ The locale that resolved from path
 ## Throws
 
 Throws the `RangeError` if the language in the path, that is not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getPathLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/getQueryLocale.md
+++ b/docs/hono/functions/getQueryLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / getQueryLocale
 
-# Function: getQueryLocale()
+# ~~Function: getQueryLocale()~~
 
 ```ts
 function getQueryLocale(context, options): Locale;
@@ -28,3 +28,7 @@ The locale that resolved from query
 ## Throws
 
 Throws the `RangeError` if the language in the query, that is not a well-formed BCP 47 language tag.
+
+## Deprecated
+
+since v2. Use `getQueryLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/setCookieLocale.md
+++ b/docs/hono/functions/setCookieLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / setCookieLocale
 
-# Function: setCookieLocale()
+# ~~Function: setCookieLocale()~~
 
 ```ts
 function setCookieLocale(
@@ -45,3 +45,7 @@ app.use('/', c => {
 ## Throws
 
 Throws the `SyntaxError` if `locale` is invalid.
+
+## Deprecated
+
+since v2. Use `setCookieLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/tryCookieLocale.md
+++ b/docs/hono/functions/tryCookieLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / tryCookieLocale
 
-# Function: tryCookieLocale()
+# ~~Function: tryCookieLocale()~~
 
 ```ts
 function tryCookieLocale(context, options): Locale | null;
@@ -28,3 +28,7 @@ The locale that resolved from cookie, if `lang` option or cookie name value are 
 ## Description
 
 Unlike [`getCookieLocale`](getCookieLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryCookieLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/tryHeaderLocale.md
+++ b/docs/hono/functions/tryHeaderLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / tryHeaderLocale
 
-# Function: tryHeaderLocale()
+# ~~Function: tryHeaderLocale()~~
 
 ```ts
 function tryHeaderLocale(context, options): Locale | null;
@@ -28,3 +28,7 @@ A first locale that resolved from header string. if you use `accept-language` he
 ## Description
 
 wrap language tag with Intl.Locale \| locale, languages tags will be parsed from `accept-language` header as default. Unlike [getHeaderLocale](getHeaderLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryHeaderLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/tryHeaderLocales.md
+++ b/docs/hono/functions/tryHeaderLocales.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / tryHeaderLocales
 
-# Function: tryHeaderLocales()
+# ~~Function: tryHeaderLocales()~~
 
 ```ts
 function tryHeaderLocales(context, options): Locale[] | null;
@@ -28,3 +28,7 @@ Some locales that wrapped from header, if you use `accept-language` header and `
 ## Description
 
 wrap language tags with Intl.Locale \| locale, languages tags will be parsed from `accept-language` header as default. Unlike [getHeaderLocales](getHeaderLocales.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryHeaderLocales` of `@intlify/utils` instead.

--- a/docs/hono/functions/tryPathLocale.md
+++ b/docs/hono/functions/tryPathLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / tryPathLocale
 
-# Function: tryPathLocale()
+# ~~Function: tryPathLocale()~~
 
 ```ts
 function tryPathLocale(context, options): Locale | null;
@@ -28,3 +28,7 @@ The locale that resolved from path. if the language in the path, that is not a w
 ## Description
 
 Unlike [`getPathLocale`](getPathLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryPathLocale` of `@intlify/utils` instead.

--- a/docs/hono/functions/tryQueryLocale.md
+++ b/docs/hono/functions/tryQueryLocale.md
@@ -4,7 +4,7 @@
 
 [@intlify/utils](../../index.md) / [hono](../index.md) / tryQueryLocale
 
-# Function: tryQueryLocale()
+# ~~Function: tryQueryLocale()~~
 
 ```ts
 function tryQueryLocale(context, options): Locale | null;
@@ -28,3 +28,7 @@ The locale that resolved from query. if the language in the query, that is not a
 ## Description
 
 Unlike [`getQueryLocale`](getQueryLocale.md), this function does not throw an error if the locale cannot be obtained, this function returns `null`.
+
+## Deprecated
+
+since v2. Use `tryQueryLocale` of `@intlify/utils` instead.

--- a/docs/hono/index.md
+++ b/docs/hono/index.md
@@ -18,16 +18,16 @@ import { getHeaderLocale, setCookieLocale } from '@intlify/utils/hono'
 
 | Function | Description |
 | ------ | ------ |
-| [getCookieLocale](functions/getCookieLocale.md) | get locale from cookie |
-| [getHeaderLanguage](functions/getHeaderLanguage.md) | get language from header |
-| [getHeaderLanguages](functions/getHeaderLanguages.md) | get languages from header |
-| [getHeaderLocale](functions/getHeaderLocale.md) | get locale from header |
-| [getHeaderLocales](functions/getHeaderLocales.md) | get locales from header |
-| [getPathLocale](functions/getPathLocale.md) | get the locale from the path |
-| [getQueryLocale](functions/getQueryLocale.md) | get the locale from the query |
-| [setCookieLocale](functions/setCookieLocale.md) | set locale to the response `Set-Cookie` header. |
-| [tryCookieLocale](functions/tryCookieLocale.md) | try to get locale from cookie |
-| [tryHeaderLocale](functions/tryHeaderLocale.md) | try to get locale from header |
-| [tryHeaderLocales](functions/tryHeaderLocales.md) | try to get locales from header |
-| [tryPathLocale](functions/tryPathLocale.md) | try to get the locale from the path |
-| [tryQueryLocale](functions/tryQueryLocale.md) | try to get the locale from the query |
+| [~~getCookieLocale~~](functions/getCookieLocale.md) | get locale from cookie |
+| [~~getHeaderLanguage~~](functions/getHeaderLanguage.md) | get language from header |
+| [~~getHeaderLanguages~~](functions/getHeaderLanguages.md) | get languages from header |
+| [~~getHeaderLocale~~](functions/getHeaderLocale.md) | get locale from header |
+| [~~getHeaderLocales~~](functions/getHeaderLocales.md) | get locales from header |
+| [~~getPathLocale~~](functions/getPathLocale.md) | get the locale from the path |
+| [~~getQueryLocale~~](functions/getQueryLocale.md) | get the locale from the query |
+| [~~setCookieLocale~~](functions/setCookieLocale.md) | set locale to the response `Set-Cookie` header. |
+| [~~tryCookieLocale~~](functions/tryCookieLocale.md) | try to get locale from cookie |
+| [~~tryHeaderLocale~~](functions/tryHeaderLocale.md) | try to get locale from header |
+| [~~tryHeaderLocales~~](functions/tryHeaderLocales.md) | try to get locales from header |
+| [~~tryPathLocale~~](functions/tryPathLocale.md) | try to get the locale from the path |
+| [~~tryQueryLocale~~](functions/tryQueryLocale.md) | try to get the locale from the query |

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -60,6 +60,8 @@ import type {
  * @param options - The {@link HeaderOptions | header options} object. `name` option is `accept-language` as default.
  *
  * @returns The array of language tags, if you use `accept-language` header and `*` (any language) or empty string is detected, return an empty array.
+ *
+ * @deprecated since v2. Use `getHeaderLanguages` of `@intlify/utils` instead.
  */
 export function getHeaderLanguages(event: H3Event, options: HeaderOptions = {}): string[] {
   warnOnce(
@@ -98,6 +100,8 @@ export function getHeaderLanguages(event: H3Event, options: HeaderOptions = {}):
  * @param options - The {@link HeaderOptions | header options} object
  *
  * @returns The **first language tag** of header, if header is not exists, or `*` (any language), return empty string.
+ *
+ * @deprecated since v2. Use `getHeaderLanguage` of `@intlify/utils` instead.
  */
 export function getHeaderLanguage(event: H3Event, options: HeaderOptions = {}): string {
   warnOnce(
@@ -132,6 +136,8 @@ export function getHeaderLanguage(event: H3Event, options: HeaderOptions = {}): 
  * @throws {RangeError} Throws the {@linkcode RangeError} if header are not a well-formed BCP 47 language tag.
  *
  * @returns The locales that wrapped from header, if you use `accept-language` header and `*` (any language) or empty string is detected, return an empty array.
+ *
+ * @deprecated since v2. Use `getHeaderLocales` of `@intlify/utils` instead.
  */
 export function getHeaderLocales(event: H3Event, options: HeaderOptions = {}): Intl.Locale[] {
   warnOnce(
@@ -150,6 +156,8 @@ export function getHeaderLocales(event: H3Event, options: HeaderOptions = {}): I
  * @param options - The {@link HeaderOptions | header options} object
  *
  * @returns The locales that wrapped from header, if you use `accept-language` header and `*` (any language) or empty string is detected, return an empty array. if header are not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryHeaderLocales` of `@intlify/utils` instead.
  */
 export function tryHeaderLocales(
   event: H3Event,
@@ -191,6 +199,8 @@ export function tryHeaderLocales(
  * @throws {RangeError} Throws the {@linkcode RangeError} if `lang` option or header are not a well-formed BCP 47 language tag.
  *
  * @returns The first locale that resolved from header string. if you use `accept-language` header and `*` (any language) or empty string is detected, return `en-US`.
+ *
+ * @deprecated since v2. Use `getHeaderLocale` of `@intlify/utils` instead.
  */
 export function getHeaderLocale(
   event: H3Event,
@@ -217,6 +227,8 @@ export function getHeaderLocale(
  * @param options - The {@link HeaderOptions | header options} object
  *
  * @returns The first locale that resolved from header string. if you use `accept-language` header and `*` (any language) or empty string is detected, return `en-US`. if header are not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryHeaderLocale` of `@intlify/utils` instead.
  */
 export function tryHeaderLocale(
   event: H3Event,
@@ -256,6 +268,8 @@ export function tryHeaderLocale(
  * @throws {RangeError} Throws a {@linkcode RangeError} if `lang` option or cookie name value are not a well-formed BCP 47 language tag.
  *
  * @returns The locale that resolved from cookie
+ *
+ * @deprecated since v2. Use `getCookieLocale` of `@intlify/utils` instead.
  */
 export function getCookieLocale(event: H3Event, options: CookieLocaleOptions = {}): Intl.Locale {
   warnOnce(
@@ -275,6 +289,8 @@ export function getCookieLocale(event: H3Event, options: CookieLocaleOptions = {
  * @param options - The {@link CookieLocaleOptions | cookie locale options}
  *
  * @returns The locale that resolved from cookie. if `lang` option or cookie name value are not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryCookieLocale` of `@intlify/utils` instead.
  */
 export function tryCookieLocale(
   event: H3Event,
@@ -312,6 +328,8 @@ export function tryCookieLocale(
  * @param options - The {@link CookieOptions | cookie options}, `name` option is `i18n_locale` as default
  *
  * @throws {SyntaxError} Throws the {@linkcode SyntaxError} if `locale` is invalid.
+ *
+ * @deprecated since v2. Use `setCookieLocale` of `@intlify/utils` instead.
  */
 export function setCookieLocale(
   event: H3Event,
@@ -336,6 +354,8 @@ export function setCookieLocale(
  * @throws {RangeError} Throws the {@linkcode RangeError} if the language in the path, that is not a well-formed BCP 47 language tag.
  *
  * @returns The locale that resolved from path
+ *
+ * @deprecated since v2. Use `getPathLocale` of `@intlify/utils` instead.
  */
 export function getPathLocale(event: H3Event, options: PathOptions = {}): Intl.Locale {
   warnOnce(
@@ -354,6 +374,8 @@ export function getPathLocale(event: H3Event, options: PathOptions = {}): Intl.L
  * @param options - the {@link PathOptions | path options} object
  *
  * @returns The locale that resolved from path. if the language in the path, that is not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryPathLocale` of `@intlify/utils` instead.
  */
 export function tryPathLocale(event: H3Event, options: PathOptions = {}): Intl.Locale | null {
   warnOnce(
@@ -376,6 +398,8 @@ export function tryPathLocale(event: H3Event, options: PathOptions = {}): Intl.L
  * @throws {RangeError} Throws the {@linkcode RangeError} if the language in the query, that is not a well-formed BCP 47 language tag.
  *
  * @returns The locale that resolved from query
+ *
+ * @deprecated since v2. Use `getQueryLocale` of `@intlify/utils` instead.
  */
 export function getQueryLocale(event: H3Event, options: QueryOptions = {}): Intl.Locale {
   warnOnce(
@@ -395,6 +419,8 @@ export function getQueryLocale(event: H3Event, options: QueryOptions = {}): Intl
  * @param options - The {@link QueryOptions | query options}, `lang` option is `en-US` as default, `name` option is `locale` as default.
  *
  * @returns The locale that resolved from query. if the language in the query, that is not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryQueryLocale` of `@intlify/utils` instead.
  */
 export function tryQueryLocale(event: H3Event, options: QueryOptions = {}): Intl.Locale | null {
   warnOnce(

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -56,6 +56,8 @@ type CookieOptions = Parameters<typeof setCookie>[3] & { name?: string }
  * @param options - The {@link HeaderOptions | header options} object. `name` option is `accept-language` as default.
  *
  * @returns An array of language tags, if you use `accept-language` header and `*` (any language) or empty string is detected, return an empty array.
+ *
+ * @deprecated since v2. Use `getHeaderLanguages` of `@intlify/utils` instead.
  */
 export function getHeaderLanguages(context: Context, options: HeaderOptions = {}): string[] {
   warnOnce(
@@ -90,6 +92,8 @@ export function getHeaderLanguages(context: Context, options: HeaderOptions = {}
  * @param options - The {@link HeaderOptions | header options} object
  *
  * @returns A **first language tag** of header, if header is not exists, or `*` (any language), return empty string.
+ *
+ * @deprecated since v2. Use `getHeaderLanguage` of `@intlify/utils` instead.
  */
 export function getHeaderLanguage(context: Context, options: HeaderOptions = {}): string {
   warnOnce(
@@ -125,6 +129,8 @@ export function getHeaderLanguage(context: Context, options: HeaderOptions = {})
  * @throws {RangeError} Throws the {@linkcode RangeError} if header are not a well-formed BCP 47 language tag.
  *
  * @returns Some locales that wrapped from header, if you use `accept-language` header and `*` (any language) or empty string is detected, return an empty array.
+ *
+ * @deprecated since v2. Use `getHeaderLocales` of `@intlify/utils` instead.
  */
 export function getHeaderLocales(context: Context, options: HeaderOptions = {}): Intl.Locale[] {
   warnOnce(
@@ -143,6 +149,8 @@ export function getHeaderLocales(context: Context, options: HeaderOptions = {}):
  * @param options - The {@link HeaderOptions | header options} object
  *
  * @returns Some locales that wrapped from header, if you use `accept-language` header and `*` (any language) or empty string is detected, return an empty array. if header are not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryHeaderLocales` of `@intlify/utils` instead.
  */
 export function tryHeaderLocales(
   context: Context,
@@ -184,6 +192,8 @@ export function tryHeaderLocales(
  * @throws {RangeError} Throws the {@linkcode RangeError} if `lang` option or header are not a well-formed BCP 47 language tag.
  *
  * @returns A first locale that resolved from header string. if you use `accept-language` header and `*` (any language) or empty string is detected, return `en-US`.
+ *
+ * @deprecated since v2. Use `getHeaderLocale` of `@intlify/utils` instead.
  */
 export function getHeaderLocale(
   context: Context,
@@ -210,6 +220,8 @@ export function getHeaderLocale(
  * @param options - The {@link HeaderOptions | header options} object
  *
  * @returns A first locale that resolved from header string. if you use `accept-language` header and `*` (any language) or empty string is detected, return `en-US`. if `lang` option or header are not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryHeaderLocale` of `@intlify/utils` instead.
  */
 export function tryHeaderLocale(
   context: Context,
@@ -250,6 +262,8 @@ export function tryHeaderLocale(
  * @throws {RangeError} Throws a {@linkcode RangeError} if `lang` option or cookie name value are not a well-formed BCP 47 language tag.
  *
  * @returns The locale that resolved from cookie
+ *
+ * @deprecated since v2. Use `getCookieLocale` of `@intlify/utils` instead.
  */
 export function getCookieLocale(context: Context, options: CookieLocaleOptions = {}): Intl.Locale {
   warnOnce(
@@ -269,6 +283,8 @@ export function getCookieLocale(context: Context, options: CookieLocaleOptions =
  * @param options - The {@link CookieLocaleOptions | cookie locale options}
  *
  * @returns The locale that resolved from cookie, if `lang` option or cookie name value are not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryCookieLocale` of `@intlify/utils` instead.
  */
 export function tryCookieLocale(
   context: Context,
@@ -307,6 +323,8 @@ export function tryCookieLocale(
  * @param options - The {@link CookieOptions | cookie options}, `name` option is `i18n_locale` as default
  *
  * @throws {SyntaxError} Throws the {@linkcode SyntaxError} if `locale` is invalid.
+ *
+ * @deprecated since v2. Use `setCookieLocale` of `@intlify/utils` instead.
  */
 export function setCookieLocale(
   context: Context,
@@ -331,6 +349,8 @@ export function setCookieLocale(
  * @throws {RangeError} Throws the {@linkcode RangeError} if the language in the path, that is not a well-formed BCP 47 language tag.
  *
  * @returns The locale that resolved from path
+ *
+ * @deprecated since v2. Use `getPathLocale` of `@intlify/utils` instead.
  */
 export function getPathLocale(context: Context, options: PathOptions = {}): Intl.Locale {
   warnOnce(
@@ -349,6 +369,8 @@ export function getPathLocale(context: Context, options: PathOptions = {}): Intl
  * @param options - the {@link PathOptions | path options} object
  *
  * @returns The locale that resolved from path. if the language in the path, that is not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryPathLocale` of `@intlify/utils` instead.
  */
 export function tryPathLocale(context: Context, options: PathOptions = {}): Intl.Locale | null {
   warnOnce(
@@ -371,6 +393,8 @@ export function tryPathLocale(context: Context, options: PathOptions = {}): Intl
  * @throws {RangeError} Throws the {@linkcode RangeError} if the language in the query, that is not a well-formed BCP 47 language tag.
  *
  * @returns The locale that resolved from query
+ *
+ * @deprecated since v2. Use `getQueryLocale` of `@intlify/utils` instead.
  */
 export function getQueryLocale(context: Context, options: QueryOptions = {}): Intl.Locale {
   warnOnce(
@@ -390,6 +414,8 @@ export function getQueryLocale(context: Context, options: QueryOptions = {}): In
  * @param options - The {@link QueryOptions | query options}, `lang` option is `en-US` as default, `name` option is `locale` as default.
  *
  * @returns The locale that resolved from query. if the language in the query, that is not a well-formed BCP 47 language tag, return `null`.
+ *
+ * @deprecated since v2. Use `tryQueryLocale` of `@intlify/utils` instead.
  */
 export function tryQueryLocale(context: Context, options: QueryOptions = {}): Intl.Locale | null {
   warnOnce(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/utils/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Multiple locale utility functions have been marked as deprecated and will be removed in a future release. Users are directed to use equivalent utilities from the `@intlify/utils` package instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->